### PR TITLE
Stops newly created contacts being marked as duplicates

### DIFF
--- a/tcintercom/app/views.py
+++ b/tcintercom/app/views.py
@@ -153,11 +153,12 @@ async def check_email_exists(item: dict):
                     'email': contact['email'],
                     'custom_attributes': contact['custom_attributes'],
                 }
-                if contact['id'] != item['id']:
+                # no point updating an already marked contact
+                if contact['id'] != item['id'] and not contact['custom_attributes'].get('is_duplicate'):
                     update_existing_contact['custom_attributes']['is_duplicate'] = True
+                    await intercom_request(f'/contacts/{contact["id"]}', method='PUT', data=update_existing_contact)
 
-                await intercom_request(f'/contacts/{contact["id"]}', method='PUT', data=update_existing_contact)
-
+            # sometimes new contact isnt included in existing conatacts
             update_existing_contact = {
                 'role': item['type'],
                 'email': item['email'],

--- a/tcintercom/app/views.py
+++ b/tcintercom/app/views.py
@@ -153,12 +153,18 @@ async def check_email_exists(item: dict):
                     'email': contact['email'],
                     'custom_attributes': contact['custom_attributes'],
                 }
-                if contact['id'] == item['id']:
-                    update_existing_contact['custom_attributes']['is_duplicate'] = False
-                else:
+                if contact['id'] != item['id']:
                     update_existing_contact['custom_attributes']['is_duplicate'] = True
 
                 await intercom_request(f'/contacts/{contact["id"]}', method='PUT', data=update_existing_contact)
+
+            update_existing_contact = {
+                'role': item['type'],
+                'email': item['email'],
+                'custom_attributes': item['custom_attributes'],
+            }
+            update_existing_contact['custom_attributes']['is_duplicate'] = False
+            await intercom_request(f'/contacts/{item["id"]}', method='PUT', data=update_existing_contact)
             msg = 'Email is a duplicate.'
         else:
             msg = 'Email is not a duplicate.'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,6 +82,10 @@ return_dict = {
         'data': [{'role': 'user', 'id': 122, 'email': 'test@test', 'custom_attributes': {}}],
         'total_count': 1,
     },
+    'dupe_email_already_true': {
+        'data': [{'role': 'user', 'id': 122, 'email': 'test@test', 'custom_attributes': {'is_duplicate': True}}],
+        'total_count': 1,
+    },
     'no_companies': {'companies': {'type': 'list', 'data': []}},
 }
 
@@ -236,6 +240,18 @@ def test_new_user_no_email(client):
 def test_new_user_dupe_email(monkeypatch, client):
     monkeypatch.setattr(conf, 'ic_token', 'foobar')
     monkeypatch.setattr(session, 'request', get_mock_response('dupe_email'))
+
+    ic_data = {
+        'topic': 'user.created',
+        'data': {'item': {'type': 'user', 'id': 123, 'email': 'test@test', 'custom_attributes': {}}},
+    }
+    r = client.post('/callback/', json=ic_data)
+    assert r.json() == {'message': 'Email is a duplicate.'}
+
+
+def test_new_user_dupe_email_already_true(monkeypatch, client):
+    monkeypatch.setattr(conf, 'ic_token', 'foobar')
+    monkeypatch.setattr(session, 'request', get_mock_response('dupe_email_already_true'))
 
     ic_data = {
         'topic': 'user.created',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,11 +76,10 @@ def get_mock_response(test, error=False):
 
 return_dict = {
     'no_dupe_email': {
-        'item': {'role': 'user', 'id': 123, 'email': 'test1@test', 'custom_attributes': {}},
         'total_count': 0,
     },
     'dupe_email': {
-        'item': {'role': 'user', 'id': 123, 'email': 'test@test', 'custom_attributes': {}},
+        'data': [{'role': 'user', 'id': 122, 'email': 'test@test', 'custom_attributes': {}}],
         'total_count': 1,
     },
     'no_companies': {'companies': {'type': 'list', 'data': []}},
@@ -219,7 +218,7 @@ def test_new_user_no_dupe_email(monkeypatch, client):
 
     ic_data = {
         'topic': 'user.created',
-        'data': {'item': {'role': 'user', 'id': 1234, 'email': 'test2@test.com', 'custom_attributes': {}}},
+        'data': {'item': {'type': 'user', 'id': 1234, 'email': 'test2@test.com', 'custom_attributes': {}}},
     }
     r = client.post('/callback/', json=ic_data)
     assert r.json() == {'message': 'Email is not a duplicate.'}
@@ -228,7 +227,7 @@ def test_new_user_no_dupe_email(monkeypatch, client):
 def test_new_user_no_email(client):
     ic_data = {
         'topic': 'user.created',
-        'data': {'item': {'role': 'user', 'id': 123, 'email': None, 'custom_attributes': {}}},
+        'data': {'item': {'type': 'user', 'id': 123, 'email': None, 'custom_attributes': {}}},
     }
     r = client.post('/callback/', json=ic_data)
     assert r.json() == {'message': 'No email provided.'}
@@ -240,7 +239,7 @@ def test_new_user_dupe_email(monkeypatch, client):
 
     ic_data = {
         'topic': 'user.created',
-        'data': {'item': {'role': 'user', 'id': 123, 'email': 'test@test', 'custom_attributes': {}}},
+        'data': {'item': {'type': 'user', 'id': 123, 'email': 'test@test', 'custom_attributes': {}}},
     }
     r = client.post('/callback/', json=ic_data)
     assert r.json() == {'message': 'Email is a duplicate.'}


### PR DESCRIPTION
Currently newly created accounts are being written as duplicates because the script is reading the newly created account then judging that because it exists that it is a duplicate.

This change will change this so that newly created contacts will be marked as not duplicate and previous ones will be marked as duplicate